### PR TITLE
Fix pydantic usage in CRUD functions

### DIFF
--- a/backend/app/api/v1/endpoints/users.py
+++ b/backend/app/api/v1/endpoints/users.py
@@ -98,7 +98,9 @@ async def update_user_me(
     - **full_name**: User's full name
     """
     # Log the update attempt
-    logger.info(f"Updating user {current_user.id} with data: {user_in.dict(exclude_unset=True)}")
+    logger.info(
+        f"Updating user {current_user.id} with data: {user_in.model_dump(exclude_unset=True)}"
+    )
     
     # Update the user
     user = crud_user.update_user(db, user_id=current_user.id, user_update=user_in)

--- a/backend/app/crud/story.py
+++ b/backend/app/crud/story.py
@@ -62,7 +62,7 @@ def update_story(
     if db_story is None:
         return None
 
-    update_data = story.dict(exclude_unset=True)
+    update_data = story.model_dump(exclude_unset=True)
     for field, value in update_data.items():
         setattr(db_story, field, value)
 

--- a/backend/app/crud/user.py
+++ b/backend/app/crud/user.py
@@ -63,7 +63,7 @@ def update_user(
         return None
     
     # Convert the update data to a dictionary, excluding unset fields
-    update_data = user_update.dict(exclude_unset=True)
+    update_data = user_update.model_dump(exclude_unset=True)
     
     # Handle password update if provided
     if "password" in update_data and update_data["password"]:


### PR DESCRIPTION
## Summary
- update backend CRUD functions to use `model_dump()` instead of the removed `dict()`
- adjust logging for new method

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685758c0c0a48333aef797316cec2ffe